### PR TITLE
add method to remove scheduled changes.

### DIFF
--- a/lib/chargebee_rails/subscription.rb
+++ b/lib/chargebee_rails/subscription.rb
@@ -52,6 +52,21 @@ module ChargebeeRails
     end
 
     #
+    # Remove scheduled changes to the subscription
+    #
+    def remove_scheduled_changes
+      begin
+      chargebee_subscription = ChargeBee::Subscription.remove_scheduled_changes(
+        chargebee_id
+      ).subscription
+      update(subscription_attrs(chargebee_subscription, self.plan))
+      rescue ChargeBee::InvalidRequestError
+        Rails.logger.warn("No changes are scheduled for this subscription")
+      end
+
+    end
+
+    #
     # Add or remove addons for the subscription
     # * *Args*    :
     #   - +addon_id+ -> the id of addon in chargebee


### PR DESCRIPTION
this lets you remove scheduled changes on a subscription.

I use a scheduled change when the billing-count goes down to update at the end of the month.
If that changes mid-month, it is useful to get rid of a scheduled change

note - I think the paramaw changes will disappear when/if you accept my pull request containing those commits